### PR TITLE
Add options for header names and ttl transformation

### DIFF
--- a/express-middleware/README.md
+++ b/express-middleware/README.md
@@ -41,6 +41,10 @@ app.get('/login', (rec, res) => res.send('Success'));
 - _countSuccess Boolean default(true)_ - if true request are counted even if they are successful, when set to false only request that result in an error will be counted toward rate limiting.
 - _getKey Function(request)_ - A Function that will get the unique client key out of the request object. By default `request.info.remoteAddress` is used.
 - _addHeaders Boolean default(true)_ - Add the headers 'X-RateLimit-Limit', 'X-RateLimit-Remaining', 'X-RateLimit-Reset' for routes that enable rate liming
++- _headerLimit String default('X-RateLimit-Limit')_ - name of the header that indicates the request quota
++- _headerRemaining String default('X-RateLimit-Remaining')_ - name of the header that indicates the remaining request quota
++- _headerReset String default('X-RateLimit-Reset')_ - name of the header that indicates how long until the request quota is reset
++- _ttlTransform Function(ttl)_ - A Function that allows transformation of the _ttl_ passed down from the Ralphi server.
 - _message String default('you have exceeded your request limit')_ - Error message in case limit has exceeded
 - _onError Function(error, rec, res, next) default(undefined)_ - if communication with Ralphi server results in an error, middleware will call this method and stop processing the request. By default request will be rate limited using _errorSize_ and _errorDelay_ settings
 _errorSize Integer default(1)_ - default record size if Ralphi server is not available

--- a/express-middleware/lib/middleware.js
+++ b/express-middleware/lib/middleware.js
@@ -14,7 +14,11 @@ const optionsKeys = {
 	bucket      : joi.string().alphanum().required(),
 	countSuccess: joi.boolean().default(true),
 	getKey      : joi.func().arity(1).default(getRequestIP),
+	ttlTransform: joi.func().arity(1).default(ttl => ttl),
 	addHeaders  : joi.boolean().default(true),
+	headerLimit : joi.string().default('X-RateLimit-Limit'),
+	headerRemaining: joi.string().default('X-RateLimit-Remaining'),
+	headerReset : joi.string().default('X-RateLimit-Reset'),
 	message     : joi.string().default('you have exceeded your request limit'),
 	onError     : joi.func().arity(4),
 	errorSize   : joi.number().integer().min(0).default(1),
@@ -59,11 +63,9 @@ function RalphiMiddleware (options) {
 		}
 
 		if (settings.addHeaders) {
-			res.set({
-				'X-RateLimit-Limit'    : limit.size,
-				'X-RateLimit-Remaining': limit.remaining,
-				'X-RateLimit-Reset'    : limit.ttl
-			});
+			res.set(settings.headerLimit, limit.size);
+			res.set(settings.headerRemaining, limit.remaining);
+			res.set(settings.headerReset, settings.ttlTransform(limit.ttl));
 		}
 
 		if (limit.conformant) {
@@ -84,7 +86,7 @@ function RalphiMiddleware (options) {
 		res.end = () =>  {
 			if (res.statusCode < 400) {
 				if (settings.addHeaders) {
-					res.set('X-RateLimit-Remaining', limit.remaining + 1);
+					res.set(settings.headerRemaining, limit.remaining + 1);
 				}
 				client.give(settings.bucket, key)
 					.catch(e => {

--- a/hapi-plugin/README.md
+++ b/hapi-plugin/README.md
@@ -54,10 +54,14 @@ init();
 - _client RalphiClient_ **required** - Ralphi client, used to query Ralphi server.
 - _ext String default(onPreHandler)_ - request flow hook when plugin should check rate limiting can be one of ('onPreAuth', 'onPostAuth', 'onPreHandler')
 - _allRoutes Boolean default(false)_ - if true rate limiting will be enabled by default on all routes
-- _bucket String_ bucket to use for rate limiting (**required** when _allRoutes_ is true)
+- _bucket String_ - bucket to use for rate limiting (**required** when _allRoutes_ is true)
 - _countSuccess Boolean default(true)_ - if true request are counted even if they are successful, when set to false only request that result in an error will be counted toward rate limiting.
 - _getKey Function(request)_ - A Function that will get the unique client key out of the request object. By default `request.info.remoteAddress` is used.
 - _addHeaders Boolean default(true)_ - Add the headers 'X-RateLimit-Limit', 'X-RateLimit-Remaining', 'X-RateLimit-Reset' for routes that enable rate liming
+- _headerLimit String default('X-RateLimit-Limit')_ - name of the header that indicates the request quota
+- _headerRemaining String default('X-RateLimit-Remaining')_ - name of the header that indicates the remaining request quota
+- _headerReset String default('X-RateLimit-Reset')_ - name of the header that indicates how long until the request quota is reset
+- _ttlTransform Function(ttl)_ - A Function that allows transformation of the _ttl_ passed down from the Ralphi server.
 - _message String default('you have exceeded your request limit')_ - Error message in case limit has exceeded
 - _onError Function(request, reply, Error) default(undefined)_ - if communication with Ralphi server results in an error, plugin will call this method and stop processing the request. By default request will be rate limited using _errorSize_ and _errorDelay_ settings
 _errorSize Integer default(1)_ - default record size if Ralphi server is not available


### PR DESCRIPTION
Introduce options `headerLimit`, `headerRemaining` and `headerReset`
to support defining header names.
Introduce option `ttlTransform` to support modifying the ttl format.

With the introduced options it is possible to support the "RateLimit
Header Fields for
HTTP" (https://tools.ietf.org/html/draft-polli-ratelimit-headers-01)
Internet-Draft.